### PR TITLE
Refactor : 최근 경기 수 20 -> 5로 변경

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
@@ -143,7 +143,7 @@ public class RiotClient {
         if (count != null) {
             urlBuilder.append("count=").append(count).append("&");
         } else {
-            urlBuilder.append("count=20&");
+            urlBuilder.append("count=5&");
         }
 
         urlBuilder.append("api_key=").append(apiKey);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The default number of match results now returned in match history queries has been updated to 5 instead of 20 when no specific value is provided. This change streamlines the displayed data and may enhance performance by reducing the volume of information delivered, resulting in a more focused and efficient experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->