### PR TITLE
Refactor : 큐타입에 따라 각각 10개의 match만 가져올 수 있도록 로직 변경 및 가독성을 위해 리팩토링

### DIFF
--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -199,6 +199,9 @@ public class RiotClientService {
                 }
             } catch (InterruptedException | ExecutionException e) {
                 log.error("current error: {}", e.getMessage());
+                if (e instanceof InterruptedException) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
 

--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -36,7 +36,7 @@ public class RiotClientService {
     private final VersionRepository versionRepository;
     private final FavoriteRepository favoriteRepository;
 
-    private static final int NUMBER_OF_RECENT_MATCH = 20;
+    private static final int RECENT_MATCH_COUNT = 10;
     private static final int PERIOD_OF_RECENT_MATCH = 30;
     private static final int MAX_METHOD_CALL = 100;
 
@@ -113,14 +113,13 @@ public class RiotClientService {
     }
 
     public List<String> getMatchIds(QueueType queueType, AccountRegion region, String puuid) {
-        if (queueType == QUICK) {
-            return riotClient.extractMatchIds(null, null, QUICK.getQueueId(), null, 0, 10, region, puuid);
-        }
-        if (queueType == SOLO) {
-            return riotClient.extractMatchIds(null, null, SOLO.getQueueId(), null, 0, 10, region, puuid);
-        }
-        if (queueType == FLEX) {
-            return riotClient.extractMatchIds(null, null, FLEX.getQueueId(), null, 0, 10, region, puuid);
+
+        if (queueType == QUICK || queueType == SOLO || queueType == FLEX) {
+            return riotClient.extractMatchIds(
+                    null, null,
+                    queueType.getQueueId(),
+                    null, 0, RECENT_MATCH_COUNT, region, puuid
+            );
         }
         throw new IllegalArgumentException("지원하지 않는 큐 타입입니다.");
     }

--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -157,10 +157,10 @@ public class RiotClientService {
         double averageDeath = accumulator.getAverageDeaths(totalGames);
         double averageAssist = accumulator.getAverageAssists(totalGames);
 
-        for (Map.Entry<String, Integer> entry : accumulator.champCount.entrySet()) {
+        for (Map.Entry<String, Integer> entry : accumulator.getChampCount().entrySet()) {
             String championName = entry.getKey();
             int playCount = entry.getValue();
-            int championWinCount = accumulator.winCountMap.getOrDefault(championName, 0);
+            int championWinCount = accumulator.getWinCountMap().getOrDefault(championName, 0);
 
             Favorite existingFavorite = favoriteRepository.findByAccountIdAndQueueTypeAndChampionName(accountId, queueType, championName);
 
@@ -173,7 +173,7 @@ public class RiotClientService {
         }
 
         return new MatchStats(
-                accumulator.winCount, totalGames - accumulator.winCount, totalGames, queueType,
+                accumulator.getWinCount(), totalGames - accumulator.getWinCount(), totalGames, queueType,
                 winRate, averageKill, averageDeath, averageAssist
         );
     }
@@ -227,12 +227,12 @@ public class RiotClientService {
     }
 
     private static class MatchStatAccumulator {
-        int totalKills;
-        int totalDeaths;
-        int totalAssists;
-        int winCount;
-        Map<String, Integer> champCount;
-        Map<String, Integer> winCountMap;
+        private final int totalKills;
+        private final int totalDeaths;
+        private final int totalAssists;
+        private final int winCount;
+        private final Map<String, Integer> champCount;
+        private final Map<String, Integer> winCountMap;
 
         MatchStatAccumulator(int totalKills, int totalDeaths, int totalAssists, int winCount,
                              Map<String, Integer> champCount, Map<String, Integer> winCountMap) {
@@ -242,6 +242,18 @@ public class RiotClientService {
             this.winCount = winCount;
             this.champCount = champCount;
             this.winCountMap = winCountMap;
+        }
+
+        public int getWinCount() {
+            return winCount;
+        }
+
+        public Map<String, Integer> getChampCount() {
+            return champCount;
+        }
+
+        public Map<String, Integer> getWinCountMap() {
+            return winCountMap;
         }
 
         public double getAverageKills(int totalGames) {

--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -59,11 +59,6 @@ public class RiotClientService {
         );
     }
 
-    // todo
-    //  처음 account 생성할 때 profileIconUrl을 가져오는 로직을 추가해야함?
-    //  업데이트에 SummonerResponse를 사용하고 있는데, 이걸로 가져오는게 맞는지 확인 필요
-    //
-
     public String updateProfileIconUrl(Account account) {
         SummonerResponse response = riotClient.extractSummonerInfo(account.getRiotAccountInfo().getPuuid(), account.getServer());
         int accountProfileIconId = response.getProfileIconId();
@@ -117,65 +112,19 @@ public class RiotClientService {
         return new RankStats(soloTotalGames, flexTotalGames, soloWins, soloLosses, soloWinRate, soloTier, soloRank, flexWins, flexLosses, flexWinRate, flexTier, flexRank);
     }
 
-    public List<String> getMatchIds(QueueType queueType, int playCount, AccountRegion region, String puuid) {
-        List<String> matchIds = new ArrayList<>();
-        int totalRetrieved = 0;
-
-        // todo
-        //  1. playCount가 0인 경우는 어떻게 처리할지 고민해보기
-        //  1-1. playCount가 0인 경우는 아예 API를 호출하지 않음
-        //  2. count = 5로 고정해서 최근 5판만 가져오도록 수정
-        //  3. if (queueType == QUICK) else구문을 없애고, queueType에 따라 다르게 처리하도록 수정
-        //  3-1. queueType이 QUICK인 경우는 quickGameData를 가져오도록 수정
-        //  3-2. queueType이 SOLO인 경우는 soloRankData를 가져오고, FLEX인 경우는 flexRankData를 가져오도록 수정
-        //  4. if문에 totalRetrieved는 추후에 추가할 수 있도록 로직 수정 (현재는 최근 5판만)
-
+    public List<String> getMatchIds(QueueType queueType, AccountRegion region, String puuid) {
         if (queueType == QUICK) {
-            int start = 0;
-            while (true) {
-                List<String> partialMatchIds = riotClient.extractMatchIds(null, null, QUICK.getQueueId(), null, start, 100, region, puuid);
-                if (partialMatchIds == null || partialMatchIds.isEmpty()) {
-                    break;
-                }
-
-                matchIds.addAll(partialMatchIds);
-                totalRetrieved += partialMatchIds.size();
-                start += totalRetrieved;
-            }
-        } else {
-            // 랭크 게임의 경우 playCount에 따라 100판 단위로 API 호출
-            // todo : count = 5로 고정해서 최근 5판만 가져오도록 수정
-            //  -> 추후 Production Key 받으면 전체 판 수 가져오기
-
-            while (totalRetrieved < playCount) {
-                int count = Math.min(MAX_METHOD_CALL, playCount - totalRetrieved);
-                List<String> partialMatchIds = riotClient.extractMatchIds(
-                        null, null,
-                        queueType == SOLO ? SOLO.getQueueId() : FLEX.getQueueId(),
-
-                        null, totalRetrieved,
-                        count, region, puuid
-                );
-
-                if (partialMatchIds == null || partialMatchIds.isEmpty()) {
-                    break;
-                }
-
-                matchIds.addAll(partialMatchIds);
-                totalRetrieved += partialMatchIds.size();
-
-                // 만약 가져온 판 수가 예상보다 적다면 더 이상 호출할 필요가 없음
-                if (partialMatchIds.size() < count) {
-                    break;
-                }
-            }
+            return riotClient.extractMatchIds(null, null, QUICK.getQueueId(), null, 0, 10, region, puuid);
         }
-
-        return matchIds;
+        if (queueType == SOLO) {
+            return riotClient.extractMatchIds(null, null, SOLO.getQueueId(), null, 0, 10, region, puuid);
+        }
+        if (queueType == FLEX) {
+            return riotClient.extractMatchIds(null, null, FLEX.getQueueId(), null, 0, 10, region, puuid);
+        }
+        throw new IllegalArgumentException("지원하지 않는 큐 타입입니다.");
     }
 
-    // 수동으로 전적 정보 갱신 시 하루 안에 100번 게임을 할 가능성이 없다고 판단했습니다.
-    // 따라서 RiotClient의 getmatchIds를 한번만 호출해도 필요한 모든 정보를 다 조회할 수 있다고 생각해서, 1번만 호출하게 되었습니다.
     public List<String> updateMatchIds(QueueType queueType, LocalDateTime lastUpdatedAt, AccountRegion region, String puuid) {
         long startTime = timeUtil.convertToEpochSeconds(lastUpdatedAt);
         return riotClient.extractMatchIds(
@@ -187,72 +136,32 @@ public class RiotClientService {
 
     @Transactional
     public MatchStats getMatchStats(Long accountId, List<String> matchIds, QueueType queueType, String summonerName, String tagLine, AccountRegion region) {
-        // 초기화
-        int totalKills = 0, totalDeath = 0, totalAssists = 0, winCount = 0;
         int totalGames = matchIds.size();
         ExecutorService executorService = Executors.newFixedThreadPool(10);
 
         List<Future<FormattedMatchResponse>> futures = new ArrayList<>();
 
         for (String matchId : matchIds) {
-            Callable<FormattedMatchResponse> task = () -> {
-                long threadId = Thread.currentThread().getId();
-                String threadName = Thread.currentThread().getName();
-                log.info("Thread ID: {}, Name: {} is processing matchId: {}", threadId, threadName, matchId);
-
-                FormattedMatchResponse matchResponse = riotClient.getMatchDetails(matchId, summonerName, tagLine, region);
-                if (matchResponse != null) {
-                    return new FormattedMatchResponse(
-                            matchResponse.getChampionName(),
-                            matchResponse.getKills(),
-                            matchResponse.getDeaths(),
-                            matchResponse.getAssists(),
-                            matchResponse.isWin()
-                    );
-                }
-                return null;
-            };
+            Callable<FormattedMatchResponse> task = () -> fetchMatchData(matchId, summonerName, tagLine, region);
             futures.add(executorService.submit(task));
         }
 
-        Map<String, Integer> champCount = new HashMap<>();
-        Map<String, Integer> winCountMap = new HashMap<>();
-
-        // 결과 수집
-        for (Future<FormattedMatchResponse> future : futures) {
-            try {
-                FormattedMatchResponse result = future.get();
-                if (result != null) {
-                    champCount.put(result.getChampionName(), champCount.getOrDefault(result.getChampionName(), 0) + 1);
-                    totalKills += result.getKills();
-                    totalDeath += result.getDeaths();
-                    totalAssists += result.getAssists();
-
-                    if (result.isWin()) {
-                        winCount++;
-                        winCountMap.put(result.getChampionName(), winCountMap.getOrDefault(result.getChampionName(), 0) + 1);
-                    }
-                }
-            } catch (InterruptedException | ExecutionException e) {
-                log.error("current error: {}", e.getMessage());
-            }
-        }
+        MatchStatAccumulator accumulator = collectMatchStats(futures);
 
         executorService.shutdown();
 
         double winRate = 0;
-        if (queueType == QUICK && totalGames > 0) {
-            winRate = (double) winCount / totalGames * 100;
+        if (queueType == QUICK) {
+            winRate = accumulator.getWinRate(totalGames);
         }
-        double averageKill = (double) totalKills / totalGames;
-        double averageDeath = (double) totalDeath / totalGames;
-        double averageAssist = (double) totalAssists / totalGames;
+        double averageKill = accumulator.getAverageKills(totalGames);
+        double averageDeath = accumulator.getAverageDeaths(totalGames);
+        double averageAssist = accumulator.getAverageAssists(totalGames);
 
-        // accountId, queueType, championName으로 생성된 Favorite이 있으면 업데이트하고, 없으면 새로 만든다.
-        for (Map.Entry<String, Integer> entry : champCount.entrySet()) {
+        for (Map.Entry<String, Integer> entry : accumulator.champCount.entrySet()) {
             String championName = entry.getKey();
             int playCount = entry.getValue();
-            int championWinCount = winCountMap.getOrDefault(championName, 0);
+            int championWinCount = accumulator.winCountMap.getOrDefault(championName, 0);
 
             Favorite existingFavorite = favoriteRepository.findByAccountIdAndQueueTypeAndChampionName(accountId, queueType, championName);
 
@@ -265,8 +174,88 @@ public class RiotClientService {
         }
 
         return new MatchStats(
-                winCount, totalGames - winCount, totalGames, queueType,
+                accumulator.winCount, totalGames - accumulator.winCount, totalGames, queueType,
                 winRate, averageKill, averageDeath, averageAssist
         );
+    }
+
+    private MatchStatAccumulator collectMatchStats(List<Future<FormattedMatchResponse>> futures) {
+        int totalKills = 0, totalDeaths = 0, totalAssists = 0, winCount = 0;
+        Map<String, Integer> champCount = new HashMap<>();
+        Map<String, Integer> winCountMap = new HashMap<>();
+
+        for (Future<FormattedMatchResponse> future : futures) {
+            try {
+                FormattedMatchResponse result = future.get();
+                if (result != null) {
+                    champCount.put(result.getChampionName(), champCount.getOrDefault(result.getChampionName(), 0) + 1);
+                    totalKills += result.getKills();
+                    totalDeaths += result.getDeaths();
+                    totalAssists += result.getAssists();
+
+                    if (result.isWin()) {
+                        winCount++;
+                        winCountMap.put(result.getChampionName(), winCountMap.getOrDefault(result.getChampionName(), 0) + 1);
+                    }
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                log.error("current error: {}", e.getMessage());
+            }
+        }
+
+        return new MatchStatAccumulator(totalKills, totalDeaths, totalAssists, winCount, champCount, winCountMap);
+    }
+
+    private FormattedMatchResponse fetchMatchData(String matchId, String summonerName, String tagLine, AccountRegion region) {
+        long threadId = Thread.currentThread().getId();
+        String threadName = Thread.currentThread().getName();
+        log.info("Thread ID: {}, Name: {} is processing matchId: {}", threadId, threadName, matchId);
+
+        FormattedMatchResponse matchResponse = riotClient.getMatchDetails(matchId, summonerName, tagLine, region);
+        if (matchResponse != null) {
+            return new FormattedMatchResponse(
+                matchResponse.getChampionName(),
+                matchResponse.getKills(),
+                matchResponse.getDeaths(),
+                matchResponse.getAssists(),
+                matchResponse.isWin()
+            );
+        }
+        return null;
+    }
+
+    private static class MatchStatAccumulator {
+        int totalKills;
+        int totalDeaths;
+        int totalAssists;
+        int winCount;
+        Map<String, Integer> champCount;
+        Map<String, Integer> winCountMap;
+
+        MatchStatAccumulator(int totalKills, int totalDeaths, int totalAssists, int winCount,
+                             Map<String, Integer> champCount, Map<String, Integer> winCountMap) {
+            this.totalKills = totalKills;
+            this.totalDeaths = totalDeaths;
+            this.totalAssists = totalAssists;
+            this.winCount = winCount;
+            this.champCount = champCount;
+            this.winCountMap = winCountMap;
+        }
+
+        public double getAverageKills(int totalGames) {
+            return totalGames == 0 ? 0 : (double) totalKills / totalGames;
+        }
+
+        public double getAverageDeaths(int totalGames) {
+            return totalGames == 0 ? 0 : (double) totalDeaths / totalGames;
+        }
+
+        public double getAverageAssists(int totalGames) {
+            return totalGames == 0 ? 0 : (double) totalAssists / totalGames;
+        }
+
+        public double getWinRate(int totalGames) {
+            return totalGames == 0 ? 0 : (double) winCount / totalGames * 100;
+        }
     }
 }

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -54,20 +54,25 @@ public class AccountGameDataService {
         List<String> soloMatchIds = riotClientService.getMatchIds(SOLO, account.getRegion(), account.getRiotAccountInfo().getPuuid());
         List<String> flexMatchIds = riotClientService.getMatchIds(FLEX, account.getRegion(), account.getRiotAccountInfo().getPuuid());
 
-        QuickGameData quickGameData = null;
+        MatchStats quickStats = null;
         if (!quickMatchIds.isEmpty()) {
-            MatchStats quickStats = riotClientService.getMatchStats(account.getId(), quickMatchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion());
+            quickStats = riotClientService.getMatchStats(account.getId(), quickMatchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion());
+        }
+
+        QuickGameData quickGameData;
+        if (quickStats != null) {
             quickGameData = QuickGameData.of(
                     quickStats.getWins(), quickStats.getTotalGames(),
                     Kda.of(quickStats.getAverageKill(), quickStats.getAverageAssist(), quickStats.getAverageDeath())
             );
         } else {
-            quickGameData = QuickGameData.of(0, 0, Kda.of(0,0,0));
+            quickGameData = QuickGameData.of(0, 0, Kda.of(0, 0, 0));
         }
 
-        SoloRankData soloRankData = null;
+        MatchStats soloStats = null;
+        SoloRankData soloRankData;
         if (!soloMatchIds.isEmpty()) {
-            MatchStats soloStats = riotClientService.getMatchStats(account.getId(), soloMatchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion());
+            soloStats = riotClientService.getMatchStats(account.getId(), soloMatchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion());
             soloRankData = SoloRankData.of(
                     rankStats.getSoloTier(), rankStats.getSoloRank(),
                     soloStats.getWins(), soloStats.getTotalGames(),
@@ -77,9 +82,10 @@ public class AccountGameDataService {
             soloRankData = SoloRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
         }
 
-        FlexRankData flexRankData = null;
+        MatchStats flexStats = null;
+        FlexRankData flexRankData;
         if (!flexMatchIds.isEmpty()) {
-            MatchStats flexStats = riotClientService.getMatchStats(account.getId(), flexMatchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion());
+            flexStats = riotClientService.getMatchStats(account.getId(), flexMatchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion());
             flexRankData = FlexRankData.of(
                     rankStats.getFlexTier(), rankStats.getFlexRank(),
                     flexStats.getWins(), flexStats.getTotalGames(),

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -48,17 +48,11 @@ public class AccountGameDataService {
         );
         long startTime = System.currentTimeMillis();
 
-        // 랭크 정보 가져오기
         RankStats rankStats = riotClientService.getRankGameStats(account.getRiotAccountInfo().getEncryptedSummonerId(), account.getServer());
 
-        // 매치 아이디 가져오기
-        // 빠른 대전의 경우 플레이한 매치 수 정보를 사용하지 않는다.
-        // todo :
-        //  현재 수정본은 solo, flex의 경우 플레이한 매치 수를 사용하고 있다. 이 부분은 나중에 수정해야함
-        //  solo만 5경기 가져올 수 있도록? - Rate Limit때문에 or 각 5경기씩 해서 Rate limit 제한 걸기?(Bucket4j)
-        List<String> quickMatchIds = riotClientService.getMatchIds(QUICK, 0, account.getRegion(), account.getRiotAccountInfo().getPuuid());
-        List<String> soloMatchIds = riotClientService.getMatchIds(SOLO, rankStats.getSoloTotalGames(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
-        List<String> flexMatchIds = riotClientService.getMatchIds(FLEX, rankStats.getFlexTotalGames(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
+        List<String> quickMatchIds = riotClientService.getMatchIds(QUICK, account.getRegion(), account.getRiotAccountInfo().getPuuid());
+        List<String> soloMatchIds = riotClientService.getMatchIds(SOLO, account.getRegion(), account.getRiotAccountInfo().getPuuid());
+        List<String> flexMatchIds = riotClientService.getMatchIds(FLEX, account.getRegion(), account.getRiotAccountInfo().getPuuid());
 
         QuickGameData quickGameData = null;
         if (!quickMatchIds.isEmpty()) {


### PR DESCRIPTION
- 각 10판의 match만 가져오기 때문에 getMatchIds 호출할때, 랭크게임의 전체게임수는 매개변수에서 제외
- getMatchIds : 10판씩만 가져오기 때문에 로직 간소화
- getMatchStats : 기존 하나의 메서드에 복잡한 로직을 메서드화, 내부클래스, 유틸메서드로 가독성을 높임 
- AccountGameDataService : 큐타입마다 값을 가져오는 로직을 가독성있게 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced match history retrieval now consistently returns a fixed set of match records across different game modes.
- **Refactor**
	- Streamlined match statistics aggregation for clearer average, win rate, and KDA computations.
	- Improved game data event handling ensures accurate statistics presentation even when no data is available.
	- Simplified method calls for retrieving match IDs by removing unnecessary parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->