### PR TITLE
Feat : Rate limiter , Refactor : matchDetail 참여자 확인 방법 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 
     // Spring retry
     implementation 'org.springframework.retry:spring-retry'
+
+    // Bucket4j - Rate Limiting
+    implementation 'com.bucket4j:bucket4j-core:8.10.1'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/summoner/lolhaeduo/client/dto/ParticipantsResponse.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/dto/ParticipantsResponse.java
@@ -6,8 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public class ParticipantsResponse {
-    private final String riotIdGameName;
-    private final String riotIdTagline;
+    private final String puuid;
     private final int assists;
     private final String championName;
     private final int deaths;

--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
@@ -167,7 +167,7 @@ public class RiotClient {
             maxAttempts = 5,
             backoff = @Backoff(delay = 5000)
     )
-    public FormattedMatchResponse getMatchDetails(String matchId, String summonerName, String tagLine, AccountRegion region) {
+    public FormattedMatchResponse getMatchDetails(String matchId, String puuid, AccountRegion region) {
         String baseUrl = regionBaseUrls.getOrDefault(region.toString(), null);
         if (baseUrl == null) {
             throw new IllegalArgumentException("Invalid region specified: " + region);
@@ -184,7 +184,7 @@ public class RiotClient {
         }
 
         return matchResponse.getInfo().getParticipants().stream()
-                .filter(p -> summonerName.equals(p.getRiotIdGameName()) && tagLine.equals(p.getRiotIdTagline()))
+                .filter(p -> puuid.equals(p.getPuuid()))
                 .map(target -> new FormattedMatchResponse(
                         target.getChampionName(),
                         target.getKills(),

--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
@@ -200,9 +200,9 @@ public class RiotClient {
     }
 
     @Recover
-    public FormattedMatchResponse recover(RuntimeException e, String matchId, String summonerName, String tagLine, AccountRegion region) {
-        log.warn("재시도 실패: matchId={}, summoner={}, tagLine={}, region={}, 이유={}",
-                matchId, summonerName, tagLine, region, e.getMessage());
+    public FormattedMatchResponse recover(RuntimeException e, String matchId, String puuid, AccountRegion region) {
+        log.warn("재시도 실패: matchId={}, puuid={}, region={}, 이유={}",
+                matchId, puuid, region, e.getMessage());
         return null;
     }
 }

--- a/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/riot/RiotClient.java
@@ -145,7 +145,7 @@ public class RiotClient {
         if (count != null) {
             urlBuilder.append("count=").append(count).append("&");
         } else {
-            urlBuilder.append("count=5&");
+            urlBuilder.append("count=20&");
         }
 
         urlBuilder.append("api_key=").append(apiKey);
@@ -201,7 +201,8 @@ public class RiotClient {
 
     @Recover
     public FormattedMatchResponse recover(RuntimeException e, String matchId, String summonerName, String tagLine, AccountRegion region) {
-        log.error("모든 재시도 요청이 실패했습니다. matchId: {}, error: {}", matchId, e.getMessage());
+        log.warn("재시도 실패: matchId={}, summoner={}, tagLine={}, region={}, 이유={}",
+                matchId, summonerName, tagLine, region, e.getMessage());
         return null;
     }
 }

--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -188,7 +188,7 @@ public class RiotClientService {
     }
 
     @Transactional
-    public MatchStats getMatchStats(Long accountId, List<String> matchIds, QueueType queueType, String summonerName, String tagLine, AccountRegion region) {
+    public MatchStats getMatchStats(Long accountId, List<String> matchIds, QueueType queueType, String summonerName, String tagLine, AccountRegion region, String puuid) {
         int totalGames = matchIds.size();
         ExecutorService executorService = Executors.newFixedThreadPool(10);
 
@@ -279,7 +279,7 @@ public class RiotClientService {
         String threadName = Thread.currentThread().getName();
         long startTime = System.currentTimeMillis();
 
-        log.info("Thread ID: {}, Name: {} is processing matchId: {}", threadId, threadName, matchId);
+//        log.info("Thread ID: {}, Name: {} is processing matchId: {}", threadId, threadName, matchId);
 
         FormattedMatchResponse matchResponse = riotClient.getMatchDetails(matchId, summonerName, tagLine, region);
 

--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -211,9 +211,15 @@ public class RiotClientService {
     private FormattedMatchResponse fetchMatchData(String matchId, String summonerName, String tagLine, AccountRegion region) {
         long threadId = Thread.currentThread().getId();
         String threadName = Thread.currentThread().getName();
+        long startTime = System.currentTimeMillis();
+
         log.info("Thread ID: {}, Name: {} is processing matchId: {}", threadId, threadName, matchId);
 
         FormattedMatchResponse matchResponse = riotClient.getMatchDetails(matchId, summonerName, tagLine, region);
+
+        long duration = System.currentTimeMillis() - startTime;
+        log.info("matchId: {} 처리 완료 ({} ms)", matchId, duration);
+
         if (matchResponse != null) {
             return new FormattedMatchResponse(
                 matchResponse.getChampionName(),

--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -5,6 +5,7 @@ import com.summoner.lolhaeduo.client.entity.Favorite;
 import com.summoner.lolhaeduo.client.repository.FavoriteRepository;
 import com.summoner.lolhaeduo.client.repository.VersionRepository;
 import com.summoner.lolhaeduo.client.riot.RiotClient;
+import com.summoner.lolhaeduo.common.limiter.RateLimiterManager;
 import com.summoner.lolhaeduo.common.util.TimeUtil;
 import com.summoner.lolhaeduo.domain.account.dto.LinkAccountRequest;
 import com.summoner.lolhaeduo.domain.account.entity.Account;
@@ -12,6 +13,8 @@ import com.summoner.lolhaeduo.domain.account.entity.RiotAccountInfo;
 import com.summoner.lolhaeduo.domain.account.enums.AccountRegion;
 import com.summoner.lolhaeduo.domain.account.enums.AccountServer;
 import com.summoner.lolhaeduo.domain.duo.enums.QueueType;
+import com.summoner.lolhaeduo.common.exception.RateLimitExceededException;
+import io.github.bucket4j.ConsumptionProbe;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -35,18 +38,34 @@ public class RiotClientService {
     private final TimeUtil timeUtil;
     private final VersionRepository versionRepository;
     private final FavoriteRepository favoriteRepository;
+    private final RateLimiterManager rateLimiterManager;
 
-    private static final int RECENT_MATCH_COUNT = 10;
+    public static final int RECENT_QUICK_MATCH_COUNT = 20;
     private static final int PERIOD_OF_RECENT_MATCH = 30;
     private static final int MAX_METHOD_CALL = 100;
 
     public RiotAccountInfo createRiotAccountInfo(LinkAccountRequest request) {
+
+        ConsumptionProbe puuidProbe = rateLimiterManager.probe();
+        if (log.isDebugEnabled()) {
+            long waitMillis = puuidProbe.getNanosToWaitForRefill() / 1_000_000;
+            String limitSource = waitMillis > 2000 ? "2분 제한 예상" : "1초 제한 예상";
+            log.debug("[RateLimit] createRiotAccountInfo - 남은 토큰: {}, 대기 시간: {}ms, 원인: {}",
+                    puuidProbe.getRemainingTokens(),
+                    waitMillis, limitSource);
+        }
+        if (!puuidProbe.isConsumed()) {
+            throw new RateLimitExceededException("Rate limit 초과 발생 ");
+        }
         PuuidResponse puuidResponse = riotClient.extractPuuid(
                 request.getSummonerName(),
                 request.getTagLine(),
                 request.getServer().getRegion()
         );
 
+        if (!rateLimiterManager.tryConsume()) {
+            throw new RateLimitExceededException("Rate limit 초과 발생 ");
+        }
         SummonerResponse summonerResponse = riotClient.extractSummonerInfo(
                 puuidResponse.getPuuid(),
                 request.getServer()
@@ -60,6 +79,9 @@ public class RiotClientService {
     }
 
     public String updateProfileIconUrl(Account account) {
+        if (!rateLimiterManager.tryConsume()) {
+            throw new RateLimitExceededException("Rate limit 초과 발생 ");
+        }
         SummonerResponse response = riotClient.extractSummonerInfo(account.getRiotAccountInfo().getPuuid(), account.getServer());
         int accountProfileIconId = response.getProfileIconId();
 
@@ -72,6 +94,9 @@ public class RiotClientService {
     }
 
     public RankStats getRankGameStats(String summonerId, AccountServer server) {
+        if (!rateLimiterManager.tryConsume()) {
+            throw new RateLimitExceededException("Rate limit 초과 발생 ");
+        }
         List<LeagueEntryResponse> leagueInfoList = riotClient.extractLeagueInfo(summonerId, server);
 
         int soloTotalGames = 0, flexTotalGames = 0;
@@ -90,8 +115,7 @@ public class RiotClientService {
                 soloTotalGames = wins + losses;
                 soloTier = leagueInfo.getTier();
                 soloRank = leagueInfo.getRank();
-            }
-            else if (leagueInfo.getQueueType().equals(FLEX.getQueueType())) {
+            } else if (leagueInfo.getQueueType().equals(FLEX.getQueueType())) {
                 flexWins = wins;
                 flexLosses = losses;
                 flexTotalGames = wins + losses;
@@ -112,19 +136,49 @@ public class RiotClientService {
         return new RankStats(soloTotalGames, flexTotalGames, soloWins, soloLosses, soloWinRate, soloTier, soloRank, flexWins, flexLosses, flexWinRate, flexTier, flexRank);
     }
 
-    public List<String> getMatchIds(QueueType queueType, AccountRegion region, String puuid) {
+    public List<String> getMatchIds(QueueType queueType, AccountRegion region, String puuid, int matchCount) {
+        ConsumptionProbe matchIdsProbe = rateLimiterManager.probe();
+        if (log.isDebugEnabled()) {
+            long waitMillis = matchIdsProbe.getNanosToWaitForRefill() / 1_000_000;
+            String limitSource = waitMillis > 2000 ? "2분 제한 예상" : "1초 제한 예상";
+            log.debug("[RateLimit] getMatchIds - 남은 토큰: {}, 대기 시간: {}ms, 원인: {}",
+                    matchIdsProbe.getRemainingTokens(), waitMillis, limitSource);
+        }
+        if (!matchIdsProbe.isConsumed()) {
+            throw new RateLimitExceededException("Rate limit 초과 발생");
+        }
 
-        if (queueType == QUICK || queueType == SOLO || queueType == FLEX) {
+        if (queueType == QUICK) {
             return riotClient.extractMatchIds(
                     null, null,
                     queueType.getQueueId(),
-                    null, 0, RECENT_MATCH_COUNT, region, puuid
+                    null, 0, RECENT_QUICK_MATCH_COUNT, region, puuid
             );
         }
-        throw new IllegalArgumentException("지원하지 않는 큐 타입입니다.");
+
+        List<String> allMatchIds = new ArrayList<>();
+        int start = 0;
+        while (start < matchCount) {
+            int count = Math.min(MAX_METHOD_CALL, matchCount - start);
+            List<String> partialMatchIds
+                    = riotClient.extractMatchIds(
+                    null, null,
+                    queueType.getQueueId(),
+                    null, start, count, region, puuid
+            );
+            if (partialMatchIds.isEmpty()) {
+                break;
+            }
+            allMatchIds.addAll(partialMatchIds);
+            start += count;
+        }
+        return allMatchIds;
     }
 
     public List<String> updateMatchIds(QueueType queueType, LocalDateTime lastUpdatedAt, AccountRegion region, String puuid) {
+        if (!rateLimiterManager.tryConsume()) {
+            throw new RateLimitExceededException("Rate limit 초과 발생 ");
+        }
         long startTime = timeUtil.convertToEpochSeconds(lastUpdatedAt);
         return riotClient.extractMatchIds(
                 startTime, null,
@@ -209,6 +263,18 @@ public class RiotClientService {
     }
 
     private FormattedMatchResponse fetchMatchData(String matchId, String summonerName, String tagLine, AccountRegion region) {
+        ConsumptionProbe matchDataProbe = rateLimiterManager.probe();
+        if (log.isDebugEnabled()) {
+            long waitMillis = matchDataProbe.getNanosToWaitForRefill() / 1_000_000;
+            String limitSource = waitMillis > 2000 ? "2분 제한 예상" : "1초 제한 예상";
+            log.debug("[RateLimit] fetchMatchData - matchId: {}, 남은 토큰: {}, 대기 시간: {}ms, 원인: {}",
+                    matchId,
+                    matchDataProbe.getRemainingTokens(),
+                    waitMillis, limitSource);
+        }
+        if (!matchDataProbe.isConsumed()) {
+            throw new RateLimitExceededException("Rate limit 초과 발생 ");
+        }
         long threadId = Thread.currentThread().getId();
         String threadName = Thread.currentThread().getName();
         long startTime = System.currentTimeMillis();
@@ -222,13 +288,14 @@ public class RiotClientService {
 
         if (matchResponse != null) {
             return new FormattedMatchResponse(
-                matchResponse.getChampionName(),
-                matchResponse.getKills(),
-                matchResponse.getDeaths(),
-                matchResponse.getAssists(),
-                matchResponse.isWin()
+                    matchResponse.getChampionName(),
+                    matchResponse.getKills(),
+                    matchResponse.getDeaths(),
+                    matchResponse.getAssists(),
+                    matchResponse.isWin()
             );
         }
+        log.warn("matchId: {} 처리 실패 - Riot API 재시도 후에도 실패했거나 유효하지 않은 매치입니다", matchId);
         return null;
     }
 

--- a/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
+++ b/src/main/java/com/summoner/lolhaeduo/client/service/RiotClientService.java
@@ -188,14 +188,14 @@ public class RiotClientService {
     }
 
     @Transactional
-    public MatchStats getMatchStats(Long accountId, List<String> matchIds, QueueType queueType, String summonerName, String tagLine, AccountRegion region, String puuid) {
+    public MatchStats getMatchStats(Long accountId, List<String> matchIds, QueueType queueType, String puuid, AccountRegion region) {
         int totalGames = matchIds.size();
         ExecutorService executorService = Executors.newFixedThreadPool(10);
 
         List<Future<FormattedMatchResponse>> futures = new ArrayList<>();
 
         for (String matchId : matchIds) {
-            Callable<FormattedMatchResponse> task = () -> fetchMatchData(matchId, summonerName, tagLine, region);
+            Callable<FormattedMatchResponse> task = () -> fetchMatchData(matchId, puuid, region);
             futures.add(executorService.submit(task));
         }
 
@@ -262,7 +262,7 @@ public class RiotClientService {
         return new MatchStatAccumulator(totalKills, totalDeaths, totalAssists, winCount, champCount, winCountMap);
     }
 
-    private FormattedMatchResponse fetchMatchData(String matchId, String summonerName, String tagLine, AccountRegion region) {
+    private FormattedMatchResponse fetchMatchData(String matchId, String puuid, AccountRegion region) {
         ConsumptionProbe matchDataProbe = rateLimiterManager.probe();
         if (log.isDebugEnabled()) {
             long waitMillis = matchDataProbe.getNanosToWaitForRefill() / 1_000_000;
@@ -275,13 +275,14 @@ public class RiotClientService {
         if (!matchDataProbe.isConsumed()) {
             throw new RateLimitExceededException("Rate limit 초과 발생 ");
         }
+
         long threadId = Thread.currentThread().getId();
         String threadName = Thread.currentThread().getName();
         long startTime = System.currentTimeMillis();
 
 //        log.info("Thread ID: {}, Name: {} is processing matchId: {}", threadId, threadName, matchId);
 
-        FormattedMatchResponse matchResponse = riotClient.getMatchDetails(matchId, summonerName, tagLine, region);
+        FormattedMatchResponse matchResponse = riotClient.getMatchDetails(matchId, puuid, region);
 
         long duration = System.currentTimeMillis() - startTime;
         log.info("matchId: {} 처리 완료 ({} ms)", matchId, duration);

--- a/src/main/java/com/summoner/lolhaeduo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/exception/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @org.springframework.web.bind.annotation.ExceptionHandler(RateLimitExceededException.class)
     public ResponseEntity<Map<String, Object>> handleRateLimitExceeded(RateLimitExceededException ex) {
         return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(Map.of(
                 "message", ex.getMessage(),

--- a/src/main/java/com/summoner/lolhaeduo/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.summoner.lolhaeduo.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    public ResponseEntity<Map<String, Object>> handleRateLimitExceeded(RateLimitExceededException ex) {
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(Map.of(
+                "message", ex.getMessage(),
+                "code", "RATE_LIMIT_EXCEEDED",
+                "timestamp", Instant.now().toString()
+        ));
+    }
+
+}

--- a/src/main/java/com/summoner/lolhaeduo/common/exception/RateLimitExceededException.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/exception/RateLimitExceededException.java
@@ -1,0 +1,8 @@
+package com.summoner.lolhaeduo.common.exception;
+
+
+public class RateLimitExceededException extends RuntimeException {
+    public RateLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimitConfig.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimitConfig.java
@@ -13,12 +13,12 @@ public class RateLimitConfig {
     @Bean
     public Bucket riotApiBucket() {
         return Bucket.builder()
-                .addLimit(
-                        Bandwidth.builder()
-                                .capacity(20)
-                                .refillGreedy(20, Duration.ofSeconds(1)) // 1초에 20개
-                                .build()
-                )
+//                .addLimit(
+//                        Bandwidth.builder()
+//                                .capacity(20)
+//                                .refillGreedy(20, Duration.ofSeconds(1)) // 1초에 20개
+//                                .build()
+//                )
                 .addLimit(
                         Bandwidth.builder()
                                 .capacity(100)

--- a/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimitConfig.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimitConfig.java
@@ -1,0 +1,31 @@
+package com.summoner.lolhaeduo.common.limiter;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class RateLimitConfig {
+
+    @Bean
+    public Bucket riotApiBucket() {
+        return Bucket.builder()
+                .addLimit(
+                        Bandwidth.builder()
+                                .capacity(20)
+                                .refillGreedy(20, Duration.ofSeconds(1)) // 1초에 20개
+                                .build()
+                )
+                .addLimit(
+                        Bandwidth.builder()
+                                .capacity(100)
+                                .refillGreedy(100, Duration.ofMinutes(2)) // 2분에 100개
+                                .build()
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimitConfig.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimitConfig.java
@@ -2,7 +2,6 @@ package com.summoner.lolhaeduo.common.limiter;
 
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
-import io.github.bucket4j.Refill;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimiterManager.java
+++ b/src/main/java/com/summoner/lolhaeduo/common/limiter/RateLimiterManager.java
@@ -1,0 +1,21 @@
+package com.summoner.lolhaeduo.common.limiter;
+
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.ConsumptionProbe;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RateLimiterManager {
+
+    private final Bucket riotApiBucket;
+
+    public boolean tryConsume() {
+        return riotApiBucket.tryConsume(1);
+    }
+
+    public ConsumptionProbe probe() {
+        return riotApiBucket.tryConsumeAndReturnRemaining(1);
+    }
+}

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -50,9 +50,9 @@ public class AccountGameDataService {
 
         RankStats rankStats = riotClientService.getRankGameStats(account.getRiotAccountInfo().getEncryptedSummonerId(), account.getServer());
 
-        List<String> quickMatchIds = riotClientService.getMatchIds(QUICK, account.getRegion(), account.getRiotAccountInfo().getPuuid());
-        List<String> soloMatchIds = riotClientService.getMatchIds(SOLO, account.getRegion(), account.getRiotAccountInfo().getPuuid());
-        List<String> flexMatchIds = riotClientService.getMatchIds(FLEX, account.getRegion(), account.getRiotAccountInfo().getPuuid());
+        List<String> quickMatchIds = riotClientService.getMatchIds(QUICK, account.getRegion(), account.getRiotAccountInfo().getPuuid(), RiotClientService.RECENT_QUICK_MATCH_COUNT);
+        List<String> soloMatchIds = riotClientService.getMatchIds(SOLO, account.getRegion(), account.getRiotAccountInfo().getPuuid(), rankStats.getSoloWins() + rankStats.getSoloLosses());
+        List<String> flexMatchIds = riotClientService.getMatchIds(FLEX, account.getRegion(), account.getRiotAccountInfo().getPuuid(), rankStats.getFlexWins() + rankStats.getFlexLosses());
 
         QuickGameData quickGameData = fetchQuickMatchStats(account, quickMatchIds);
         SoloRankData soloRankData = fetchSoloMatchStats(account, soloMatchIds, rankStats);

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -54,52 +54,11 @@ public class AccountGameDataService {
         List<String> soloMatchIds = riotClientService.getMatchIds(SOLO, account.getRegion(), account.getRiotAccountInfo().getPuuid());
         List<String> flexMatchIds = riotClientService.getMatchIds(FLEX, account.getRegion(), account.getRiotAccountInfo().getPuuid());
 
-        MatchStats quickStats = null;
-        if (!quickMatchIds.isEmpty()) {
-            quickStats = riotClientService.getMatchStats(account.getId(), quickMatchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion());
-        }
+        QuickGameData quickGameData = fetchQuickMatchStats(account, quickMatchIds);
+        SoloRankData soloRankData = fetchSoloMatchStats(account, soloMatchIds, rankStats);
+        FlexRankData flexRankData = fetchFlexMatchStats(account, flexMatchIds, rankStats);
 
-        QuickGameData quickGameData;
-        if (quickStats != null) {
-            quickGameData = QuickGameData.of(
-                    quickStats.getWins(), quickStats.getTotalGames(),
-                    Kda.of(quickStats.getAverageKill(), quickStats.getAverageAssist(), quickStats.getAverageDeath())
-            );
-        } else {
-            quickGameData = QuickGameData.of(0, 0, Kda.of(0, 0, 0));
-        }
-
-        MatchStats soloStats = null;
-        SoloRankData soloRankData;
-        if (!soloMatchIds.isEmpty()) {
-            soloStats = riotClientService.getMatchStats(account.getId(), soloMatchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion());
-            soloRankData = SoloRankData.of(
-                    rankStats.getSoloTier(), rankStats.getSoloRank(),
-                    soloStats.getWins(), soloStats.getTotalGames(),
-                    Kda.of(soloStats.getAverageKill(), soloStats.getAverageAssist(), soloStats.getAverageDeath())
-            );
-        } else {
-            soloRankData = SoloRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
-        }
-
-        MatchStats flexStats = null;
-        FlexRankData flexRankData;
-        if (!flexMatchIds.isEmpty()) {
-            flexStats = riotClientService.getMatchStats(account.getId(), flexMatchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion());
-            flexRankData = FlexRankData.of(
-                    rankStats.getFlexTier(), rankStats.getFlexRank(),
-                    flexStats.getWins(), flexStats.getTotalGames(),
-                    Kda.of(flexStats.getAverageKill(), flexStats.getAverageAssist(), flexStats.getAverageDeath())
-            );
-        } else {
-            flexRankData = FlexRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
-        }
-
-        // 각각 데이터 객체 생성
-        // todo 
-        //  account 객체 만들때, profileIconUrl을 받을 수 있는데, 한번더 SUMMONER api를 호출해야할지 생각 해봐야함
-        //  account 객체 생성할때 accountgamedata에 profileIconUrl을 넣는건 어떨지?
-        String iconUrl = riotClientService.updateProfileIconUrl(account);
+        String iconUrl = fetchProfileIconUrl(account);
 
         AccountGameData newAccountGameData = AccountGameData.of(iconUrl, quickGameData, soloRankData, flexRankData);
         long endTime = System.currentTimeMillis();
@@ -167,6 +126,48 @@ public class AccountGameDataService {
                 flexRankDataRepository.save(flexRankData)
         );
         accountGameDataRepository.save(recentData);
+    }
+
+    private QuickGameData fetchQuickMatchStats(Account account, List<String> matchIds) {
+        if (matchIds.isEmpty()) {
+            return QuickGameData.of(0, 0, Kda.of(0, 0, 0));
+        }
+
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion());
+        return QuickGameData.of(
+                stats.getWins(), stats.getTotalGames(),
+                Kda.of(stats.getAverageKill(), stats.getAverageAssist(), stats.getAverageDeath())
+        );
+    }
+
+    private SoloRankData fetchSoloMatchStats(Account account, List<String> matchIds, RankStats rankStats) {
+        if (matchIds.isEmpty()) {
+            return SoloRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
+        }
+
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion());
+        return SoloRankData.of(
+                rankStats.getSoloTier(), rankStats.getSoloRank(),
+                stats.getWins(), stats.getTotalGames(),
+                Kda.of(stats.getAverageKill(), stats.getAverageAssist(), stats.getAverageDeath())
+        );
+    }
+
+    private FlexRankData fetchFlexMatchStats(Account account, List<String> matchIds, RankStats rankStats) {
+        if (matchIds.isEmpty()) {
+            return FlexRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
+        }
+
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion());
+        return FlexRankData.of(
+                rankStats.getFlexTier(), rankStats.getFlexRank(),
+                stats.getWins(), stats.getTotalGames(),
+                Kda.of(stats.getAverageKill(), stats.getAverageAssist(), stats.getAverageDeath())
+        );
+    }
+
+    private String fetchProfileIconUrl(Account account) {
+        return riotClientService.updateProfileIconUrl(account);
     }
 
     private Kda updateKda(Kda previousKda, int totalGames, MatchStats matchStats) {

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -91,7 +91,7 @@ public class AccountGameDataService {
         List<String> flexMatchIds = riotClientService.updateMatchIds(FLEX, modifiedAt, account.getRegion(), account.getRiotAccountInfo().getPuuid());
 
         if (!quickMatchIds.isEmpty()) {
-            MatchStats quickStats = riotClientService.getMatchStats(account.getId(), quickMatchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
+            MatchStats quickStats = riotClientService.getMatchStats(account.getId(), quickMatchIds, QUICK, account.getRiotAccountInfo().getPuuid(), account.getRegion());
             quickGameData.update(
                     quickStats.getWins(), quickStats.getTotalGames(),
                     Kda.of(quickStats.getAverageKill(), quickStats.getAverageAssist(), quickStats.getAverageDeath())
@@ -99,7 +99,7 @@ public class AccountGameDataService {
         }
 
         if (!soloMatchIds.isEmpty()) {
-            MatchStats soloStats = riotClientService.getMatchStats(account.getId(), soloMatchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
+            MatchStats soloStats = riotClientService.getMatchStats(account.getId(), soloMatchIds, SOLO, account.getRiotAccountInfo().getPuuid(), account.getRegion());
             soloRankData.update(
                     rankStats.getSoloTier(), rankStats.getSoloRank(),
                     soloRankData.getWins() + soloStats.getWins(),
@@ -109,7 +109,7 @@ public class AccountGameDataService {
         }
 
         if (!flexMatchIds.isEmpty()) {
-            MatchStats flexStats = riotClientService.getMatchStats(account.getId(), flexMatchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
+            MatchStats flexStats = riotClientService.getMatchStats(account.getId(), flexMatchIds, FLEX, account.getRiotAccountInfo().getPuuid(), account.getRegion());
             flexRankData.update(
                     rankStats.getFlexTier(), rankStats.getFlexRank(),
                     flexRankData.getWins() + flexStats.getWins(),
@@ -133,7 +133,7 @@ public class AccountGameDataService {
             return QuickGameData.of(0, 0, Kda.of(0, 0, 0));
         }
 
-        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, QUICK, account.getRiotAccountInfo().getPuuid(), account.getRegion());
         return QuickGameData.of(
                 stats.getWins(), stats.getTotalGames(),
                 Kda.of(stats.getAverageKill(), stats.getAverageAssist(), stats.getAverageDeath())
@@ -145,7 +145,7 @@ public class AccountGameDataService {
             return SoloRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
         }
 
-        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, SOLO, account.getRiotAccountInfo().getPuuid(), account.getRegion());
         return SoloRankData.of(
                 rankStats.getSoloTier(), rankStats.getSoloRank(),
                 stats.getWins(), stats.getTotalGames(),
@@ -158,7 +158,7 @@ public class AccountGameDataService {
             return FlexRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
         }
 
-        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, FLEX, account.getRiotAccountInfo().getPuuid(), account.getRegion());
         return FlexRankData.of(
                 rankStats.getFlexTier(), rankStats.getFlexRank(),
                 stats.getWins(), stats.getTotalGames(),

--- a/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
+++ b/src/main/java/com/summoner/lolhaeduo/domain/account/service/AccountGameDataService.java
@@ -91,7 +91,7 @@ public class AccountGameDataService {
         List<String> flexMatchIds = riotClientService.updateMatchIds(FLEX, modifiedAt, account.getRegion(), account.getRiotAccountInfo().getPuuid());
 
         if (!quickMatchIds.isEmpty()) {
-            MatchStats quickStats = riotClientService.getMatchStats(account.getId(), quickMatchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion());
+            MatchStats quickStats = riotClientService.getMatchStats(account.getId(), quickMatchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
             quickGameData.update(
                     quickStats.getWins(), quickStats.getTotalGames(),
                     Kda.of(quickStats.getAverageKill(), quickStats.getAverageAssist(), quickStats.getAverageDeath())
@@ -99,7 +99,7 @@ public class AccountGameDataService {
         }
 
         if (!soloMatchIds.isEmpty()) {
-            MatchStats soloStats = riotClientService.getMatchStats(account.getId(), soloMatchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion());
+            MatchStats soloStats = riotClientService.getMatchStats(account.getId(), soloMatchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
             soloRankData.update(
                     rankStats.getSoloTier(), rankStats.getSoloRank(),
                     soloRankData.getWins() + soloStats.getWins(),
@@ -109,7 +109,7 @@ public class AccountGameDataService {
         }
 
         if (!flexMatchIds.isEmpty()) {
-            MatchStats flexStats = riotClientService.getMatchStats(account.getId(), flexMatchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion());
+            MatchStats flexStats = riotClientService.getMatchStats(account.getId(), flexMatchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
             flexRankData.update(
                     rankStats.getFlexTier(), rankStats.getFlexRank(),
                     flexRankData.getWins() + flexStats.getWins(),
@@ -133,7 +133,7 @@ public class AccountGameDataService {
             return QuickGameData.of(0, 0, Kda.of(0, 0, 0));
         }
 
-        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion());
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, QUICK, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
         return QuickGameData.of(
                 stats.getWins(), stats.getTotalGames(),
                 Kda.of(stats.getAverageKill(), stats.getAverageAssist(), stats.getAverageDeath())
@@ -145,7 +145,7 @@ public class AccountGameDataService {
             return SoloRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
         }
 
-        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion());
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, SOLO, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
         return SoloRankData.of(
                 rankStats.getSoloTier(), rankStats.getSoloRank(),
                 stats.getWins(), stats.getTotalGames(),
@@ -158,7 +158,7 @@ public class AccountGameDataService {
             return FlexRankData.of("UNRANKED", "N/A", 0, 0, Kda.of(0,0,0));
         }
 
-        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion());
+        MatchStats stats = riotClientService.getMatchStats(account.getId(), matchIds, FLEX, account.getSummonerName(), account.getTagLine(), account.getRegion(), account.getRiotAccountInfo().getPuuid());
         return FlexRankData.of(
                 rankStats.getFlexTier(), rankStats.getFlexRank(),
                 stats.getWins(), stats.getTotalGames(),


### PR DESCRIPTION
- 새기능
- Bucket4j의 Rate Limiter 기능 추가 : 2분에 100회 제안

- Refactor
- matchDetail : 기존에 참여자를 SummonerName과 TagLine으로 확인 -> 이름에 띄어쓰기 구분 안하면 참여자 구분이 안되는 이슈 발생
matchDetail에 참여자 puuid도 나오기 때문에 참여자 고유의 puuid로 구분하기로 변경 

- 추후예정
- 큐를 활용하여, Rate Limit에 제한되어 요청을 보내지 못한 API에 대하여 큐에 담아서 재시도 로직 예정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced global rate limiting for Riot API requests, with clear error responses when limits are exceeded.
  - Added standardized error handling for rate limit violations, returning HTTP 429 responses with detailed messages.

- **Improvements**
  - Enhanced API reliability by enforcing rate limits and providing detailed logs on usage and wait times.
  - Streamlined participant identification by using a unified player identifier (PUUID) instead of separate Riot ID components.
  - Improved modularity and maintainability by refactoring internal logic for fetching and processing match statistics.
  - Increased default match fetch count for more comprehensive data retrieval.
  - Enhanced batch fetching of match IDs with flexible counts and queue type handling.

- **Dependency Updates**
  - Added a new library to support rate limiting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->